### PR TITLE
Update dev config so SPARQL endpoints don't route over public URLs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,17 @@
+# Copilot instructions
+
+## Build and run
+- Local dev: `docker compose -f compose.yaml.local watch` (serves http://localhost:9090/skosmos-dev/)
+- Build images: `docker build -f Dockerfile.local .`, `docker build -f Dockerfile.dev .`, `docker build -f Dockerfile.prod .`
+
+## High-level architecture
+- Docker builds clone upstream `NatLibFi/Skosmos` (v3.0), install composer/npm deps, then overlay this repo’s customizations from `./skosmos/` and a `config.ttl.*` file.
+- Environment configuration lives in `config.ttl.{local,dev,prod}` and is copied into the container as `config.ttl` to drive SPARQL endpoints, baseHref, languages, and vocabularies.
+- UI customizations are Twig overrides and assets under `skosmos/`, with `skosmos/src/view/base-template.twig` and `scripts.inc.twig` overriding upstream view behavior.
+- Deployments are GitHub Actions workflows that build Docker images and deploy to ECS on pushes to `main` (dev) or release tags (prod).
+
+## Key conventions
+- Use `config.ttl.local` for prototyping, `config.ttl.dev` for dev deployment, and `config.ttl.prod` for production; keep `skosmos:baseHref` aligned with the target instance.
+- Template overrides live in `skosmos/custom-templates/` (notably `about/`, `footer/`, `html-head/`, and `library-header/`). `library-header.twig` is also wired via `skosmos/src/view/base-template.twig`.
+- `footer.twig` and `library-header.twig` include their own CSS to support localization.
+- CSS lives in `skosmos/resource/css/` (`custom.css` for local overrides, `skosmos.css` for global styling).

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,6 +30,17 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Render config.ttl.dev
+        run: |
+          BASE="${{ secrets.GRAPHDB_INTERNAL_BASE_DEV }}"
+          if [ -z "$BASE" ]; then
+            echo "GRAPHDB_INTERNAL_BASE_DEV is not set" >&2
+            exit 1
+          fi
+          BASE="${BASE%/}"
+          sed "s|__GRAPHDB_INTERNAL_BASE__|$BASE|g" config.ttl.dev > config.ttl.dev.tmp
+          mv config.ttl.dev.tmp config.ttl.dev
+
       - name: Build Docker image
         run: |
           docker build -t ${{ steps.login-ecr.outputs.registry }}/mdu-skosmos:dev \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ When you want to deploy changes, create a branch, save your changes, and issue a
 ## Workflows and deployment
 
 Merging to main will trigger a build of the Docker image, which will then be deployed to ECS as a dev/uat server.
+The dev workflow renders `config.ttl.dev` using the `GRAPHDB_INTERNAL_BASE_DEV` GitHub Actions secret.
 
 Creating a release will build the image for that release tag and deploy it to ECS as a production server.
 

--- a/config.ttl.dev
+++ b/config.ttl.dev
@@ -21,7 +21,8 @@
 :config a skosmos:Configuration ;
     # SPARQL endpoint
     # a local Fuseki server is usually on localhost:3030
-    skosmos:sparqlEndpoint <https://metadata.un.org/graphdb/repositories/UNBIST-test_core> ;
+    # __GRAPHDB_INTERNAL_BASE__ is rendered in the deploy-dev workflow.
+    skosmos:sparqlEndpoint <__GRAPHDB_INTERNAL_BASE__/graphdb/repositories/UNBIST-test_core> ;
 
     # sparql-query extension, or "Generic" for plain SPARQL 1.1
     # set to "JenaText" instead if you use Fuseki with jena-text index
@@ -118,7 +119,7 @@
     skosmos:showNotation true ;
     skosmos:conceptSchemesInHierarchy true ;
     skosmos:mainConceptScheme <http://metadata.un.org/thesaurus/00> ;
-    void:sparqlEndpoint <https://metadata.un.org/graphdb/repositories/UNBIST_core> ;
+    void:sparqlEndpoint <__GRAPHDB_INTERNAL_BASE__/graphdb/repositories/UNBIST_core> ;
     skosmos:sparqlDialect "Generic" .
 
 :unbist2 a skosmos:Vocabulary, void:Dataset ;
@@ -141,7 +142,7 @@
     skosmos:showNotation true ;
     skosmos:conceptSchemesInHierarchy true ;
     skosmos:mainConceptScheme <http://metadata.un.org/thesaurus/00> ;
-    void:sparqlEndpoint <https://metadata.un.org/graphdb/repositories/UNBIST-test_core> ;
+    void:sparqlEndpoint <__GRAPHDB_INTERNAL_BASE__/graphdb/repositories/UNBIST-test_core> ;
     skosmos:sparqlDialect "Generic" .
 
 :sdg a skosmos:Vocabulary, void:Dataset ;
@@ -160,7 +161,7 @@
     skosmos:sortByNotation "natural" ;
     skosmos:groupClass sdgo:SDGCodeCompact ;
     skosmos:showNotation true ;
-    void:sparqlEndpoint <https://metadata.un.org/graphdb/repositories/SDG-test_core> .
+    void:sparqlEndpoint <__GRAPHDB_INTERNAL_BASE__/graphdb/repositories/SDG-test_core> .
 
 :unms a skosmos:Vocabulary, void:Dataset ;
     dc:title "UN Member States"@en, "الدول الأعضاء في منظمة الأمم المتحدة"@ar, "联合国会员国"@zh, "États membres de l'ONU"@fr, "Государства — члены ООН"@ru, "Estados Miembros de la ONU"@es ;
@@ -183,7 +184,7 @@
     skosmos:fullAlphabeticalIndex true ;
     skosmos:conceptSchemesInHierarchy true ;
     skosmos:mainConceptScheme <http://metadata.un.org/UNMS/> ;
-    void:sparqlEndpoint <https://metadata.un.org/graphdb/repositories/UNMS_core> .
+    void:sparqlEndpoint <__GRAPHDB_INTERNAL_BASE__/graphdb/repositories/UNMS_core> .
 
 :categories a skos:ConceptScheme;
     skos:prefLabel "UN Linked Data Services"@en,


### PR DESCRIPTION
Routing over public URLs for an internal resource just clobbers the nginx server that's running there, so this attempts to route directly to the graphdb URL where it's listening.