### PR TITLE
Reduce dev task memory (AWS rightsizing recommendation)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ECS_CPU: 1024
-      ECS_MEMORY: 4096
+      ECS_MEMORY: 2048
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Reduce memory allocation for the mdu-skosmos-dev cluster/task service, as recommended by AWS for rightsizing cost savings.